### PR TITLE
Use hostname with check_http

### DIFF
--- a/check_http_multiips
+++ b/check_http_multiips
@@ -78,6 +78,7 @@ sub main {
         my $ipaddr = $k->rdatastr;
         my $cmd = "$check_http";
         my @args = ("-I", $ipaddr, @ARGV);
+        unshift @args, "-H $hostname";
         unshift @args, "--ssl" if $ssl;
         if ($debug) {
             print STDERR "CMD: $cmd @args\n";


### PR DESCRIPTION
It's possible to put many hostnames on one ip-port pair, so sometimes it's important to pass `-H` parameter to check_http.
